### PR TITLE
Avoid redirection on root routes

### DIFF
--- a/app/routers/authorization.py
+++ b/app/routers/authorization.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import aiohttp
 import asyncio
 import os
+import pprint
 
 # loading config for authorization
 CLIENT_ID = os.environ["CLIENT_ID"]
@@ -139,4 +140,5 @@ async def create_new_user(name, username):
             if resp.status!=200:
                 # user does not exists
                 data = {"username": username, "name": name}
-                await session.post(f"{DOMAIN}/api/users", json=data)
+                resp = await session.post(f"{DOMAIN}/api/users", json=data)
+                pprint.pprint(resp.history)

--- a/app/routers/authorization.py
+++ b/app/routers/authorization.py
@@ -7,6 +7,7 @@ import aiohttp
 import asyncio
 import os
 import pprint
+import sys
 
 # loading config for authorization
 CLIENT_ID = os.environ["CLIENT_ID"]
@@ -141,4 +142,5 @@ async def create_new_user(name, username):
                 # user does not exists
                 data = {"username": username, "name": name}
                 resp = await session.post(f"{DOMAIN}/api/users", json=data)
-                pprint.pprint(resp.history)
+                pprint.pprint(resp.history, stream=sys.stderr)
+                pprint.pprint(resp.headers, stream=sys.stderr)

--- a/app/routers/authorization.py
+++ b/app/routers/authorization.py
@@ -6,8 +6,6 @@ from uuid import uuid4
 import aiohttp
 import asyncio
 import os
-import pprint
-import sys
 
 # loading config for authorization
 CLIENT_ID = os.environ["CLIENT_ID"]
@@ -141,6 +139,4 @@ async def create_new_user(name, username):
             if resp.status!=200:
                 # user does not exists
                 data = {"username": username, "name": name}
-                resp = await session.post(f"{DOMAIN}/api/users", json=data)
-                pprint.pprint(resp.history, stream=sys.stderr)
-                pprint.pprint(resp.headers, stream=sys.stderr)
+                await session.post(f"{DOMAIN}/api/users", json=data)

--- a/app/routers/site.py
+++ b/app/routers/site.py
@@ -37,7 +37,7 @@ async def get_current_user(request: Request):
         return None
 
 # route for home page
-@router.get("/")
+@router.get("")
 @router.get("/home", name="home")
 async def index(request: Request, user: UserRequestBody = Depends(get_current_user)):
     if user is None:

--- a/app/routers/site.py
+++ b/app/routers/site.py
@@ -37,7 +37,7 @@ async def get_current_user(request: Request):
         return None
 
 # route for home page
-@router.get("")
+@router.get("/")
 @router.get("/home", name="home")
 async def index(request: Request, user: UserRequestBody = Depends(get_current_user)):
     if user is None:
@@ -118,5 +118,3 @@ async def upload_file(file: UploadFile, username: str):
                 return 0
             else:
                 return -1
-    
-

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -9,7 +9,7 @@ import utils
 router = APIRouter(tags=["users"], prefix="/api/users")
 
 # returns list of user
-@router.get("/", response_model=List[UserModel])
+@router.get("", response_model=List[UserModel])
 async def users_list(limit: int = 10):
     return await read_users(limit=limit)
 
@@ -31,7 +31,7 @@ async def get_files_list(username: str):
         return file_list
 
 # creates new user
-@router.post("/", response_model=OperationStatusModel)
+@router.post("", response_model=OperationStatusModel)
 async def add_user(user: UserRequestBody):
     response = await create_user(name=user.name, username=user.username)
     if not response:


### PR DESCRIPTION
This PR addresses an issue where new users' profiles couldn't be created due to POST requests being redirected to an unsecured context(HTTPS -> HTTP). This leads to an unexpected method switch from POST to GET (due to an insecure context switch), resulting in an incorrect request being made to the API.

### Changes
- remove the need to add '/' for root routes which don't require them.

Fixes: #4 
Note: This issue is only seen on HTTPS (secure) connections and might not be visible in local environments, E.g. localhost.